### PR TITLE
breaking(feat): Adding debug output. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 genchlg.sh
+debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+#### 1.0.2 (2022-12-14)
+
+##### Breaking Changes
+
+* **init:**  initialize debug func. ([a6ce4ebe](https://github.com/iptoux/bash_error_lib/commit/a6ce4ebe0e65ee3f8481c15c33a6b26f349e266a))
+
+##### Documentation Changes
+
+* **git:**  Adding keywords for readme.md ([e493bab4](https://github.com/iptoux/bash_error_lib/commit/e493bab493140a51f559e1c1cfe12d0f82879106))
+
+##### Code Style Changes
+
+* **git:**  Adding badges ([c5644209](https://github.com/iptoux/bash_error_lib/commit/c5644209b778a8d69842dfa6b768624f4bd91ea6))
+
 #### 1.0.1 (2022-12-14)
 
 ##### Build System / Dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # bash_error_lib
 
+<p align="center" width="100%">
+    <img src="https://img.shields.io/github/package-json/v/iptoux/bash_error_lib?style=flat-square" title="GitHub package.json version">
+    <img src="https://img.shields.io/github/directory-file-count/iptoux/bash_error_lib/lib?style=flat-square" title="GitHub repo file count (file extension)">
+    <img src="https://img.shields.io/github/languages/code-size/iptoux/bash_error_lib?style=flat-square" title="GitHub code size in bytes">
+    <img src="https://img.shields.io/github/issues/iptoux/bash_error_lib?style=flat-square" title="GitHub issues">
+    <img src="https://img.shields.io/github/license/iptoux/bash_error_lib?style=flat-square" title="GitHub">
+    <img src="https://img.shields.io/github/commit-activity/m/iptoux/bash_error_lib?style=flat-square" title="GitHub commit activity">
+    <img src="https://img.shields.io/github/package-json/keywords/iptoux/bash_error_lib?style=flat-square" title="GitHub package.json dynamic">
+    
+</p>
+
 This is an bash error "library", an error handler for any kind of bash script. The library catches mostly all defaults script errors and syntax erros by an trap and displays/logs them.
 
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,23 @@
     <img src="https://img.shields.io/github/languages/code-size/iptoux/bash_error_lib?style=flat-square" title="GitHub code size in bytes">
     <img src="https://img.shields.io/github/issues/iptoux/bash_error_lib?style=flat-square" title="GitHub issues">
     <img src="https://img.shields.io/github/license/iptoux/bash_error_lib?style=flat-square" title="GitHub">
-    <img src="https://img.shields.io/github/commit-activity/m/iptoux/bash_error_lib?style=flat-square" title="GitHub commit activity">
     <img src="https://img.shields.io/github/package-json/keywords/iptoux/bash_error_lib?style=flat-square" title="GitHub package.json dynamic">
     
 </p>
 
 This is an bash error "library", an error handler for any kind of bash script. The library catches mostly all defaults script errors and syntax erros by an trap and displays/logs them.
+
+## Index
+
+
+- [Why](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#)
+- [How it works](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#how-it-works)
+- [Control](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#control)
+- [Screenshots/Output](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#screenshotsoutput)
+- [HowTo/Usage/Install](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#howto)
+- [Example](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#example)
+- [Todo](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#todo)
+
 
 
 ## Why?

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is an bash error "library", an error handler for any kind of bash script. T
 ## Index
 
 
-- [Why](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#)
+- [Why](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#why)
 - [How it works](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#how-it-works)
 - [Control](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#control)
 - [Screenshots/Output](https://github.com/iptoux/bash_error_lib/tree/2-debug-output#screenshotsoutput)

--- a/basherr.sh
+++ b/basherr.sh
@@ -39,8 +39,8 @@ trap 'bs_clean' EXIT
 #hello_world        # <-
 
 # Disable debug output
-#bs_debug false
-
+bs_debug false
+bs_debug true
 # Unknown command or an unknown function of
 # script.
 

--- a/basherr.sh
+++ b/basherr.sh
@@ -19,7 +19,7 @@
 . 'lib/bash_error_lib'                      # bs_debug looks for arg -$yourarg on cmd to enable it fast.
 
 # Enable Debug output.
-#bs_debug                
+bs_debug true                               # after sourcing of lib or by commandline option (set in lib)
 
 ############ LOAD TRAPS ############
 
@@ -39,8 +39,8 @@ trap 'bs_clean' EXIT
 #hello_world        # <-
 
 # Disable debug output
-bs_debug false
-bs_debug true
+bs_debug false                              # Can be disabled at any line
+
 # Unknown command or an unknown function of
 # script.
 

--- a/basherr.sh
+++ b/basherr.sh
@@ -16,7 +16,10 @@
 
 
 ############ SOURCE LIBRARY ############
-. 'lib/bash_error_lib'
+. 'lib/bash_error_lib'                      # bs_debug looks for arg -$yourarg on cmd to enable it fast.
+
+# Enable Debug output.
+#bs_debug                
 
 ############ LOAD TRAPS ############
 
@@ -30,13 +33,15 @@ trap 'bs_clean' EXIT
 
 
 # Syntax error -> nothing in function
-# hello_world() {
+#hello_world() {    # <-
+#                   # <-
+#}                  # <-
+#hello_world        # <-
 
-# }
-
-#hello_world
+# Disable debug output
+#bs_debug false
 
 # Unknown command or an unknown function of
 # script.
 
-somecommand
+#somecommand        # <-

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -22,6 +22,7 @@ ERROR_LOG=true
 ERROR_SRC_SNIPPED=true
 
 # Debug
+DEBUG_PID=$$
 DEBUG_AUTO=false
 DEBUG_OPT="-debug"
 
@@ -34,7 +35,7 @@ DATE=$(date +%m.%d.%y)
 
 LOG_DIR=""
 ERROR_FILE=${LOG_DIR}${DATE}'_error.log'
-DEBUG_FILE=${LOG_DIR}${DATE}'_debug.log'
+DEBUG_FILE=${LOG_DIR}${DATE}'_'${DEBUG_PID}'.log'
 
 # Redirect stderr to file for parsing errors....
 exec 2> 'stderr'
@@ -176,7 +177,7 @@ bs_debug() {
 
     if [ "${switch}" == "auto" ] || [ "${switch}" == true ]; then
         # open a new file descriptor for logging
-        exec 5> "${DEBUG_FILE}"
+        exec 5>> "${DEBUG_FILE}"
         # redirect trace logs to fd 5
         BASH_XTRACEFD=5
         # format output

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -160,6 +160,11 @@ bs_error_cli() {
 
 }
 
+bs_debug(){
+
+    return 0
+
+}
 # Bash error library handler
 # This is an own self written error handler, to handle function
 # and command errors during the runtime/developemnt.

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -16,10 +16,14 @@
 
 ############ LIBRARY VARIABLES ############
 
+# Error
 ERROR_EXIT=true
 ERROR_LOG=true
-
 ERROR_SRC_SNIPPED=true
+
+# Debug
+DEBUG_AUTO=false
+DEBUG_OPT="-debug"
 
 ############ RUNTIME SETS ############ 
 set +o errexit  # Deactivate default Exit after first command failure.
@@ -30,6 +34,7 @@ DATE=$(date +%m.%d.%y)
 
 LOG_DIR=""
 ERROR_FILE=${LOG_DIR}${DATE}'_error.log'
+DEBUG_FILE=${LOG_DIR}${DATE}'_debug.log'
 
 # Redirect stderr to file for parsing errors....
 exec 2> 'stderr'
@@ -160,11 +165,40 @@ bs_error_cli() {
 
 }
 
-bs_debug(){
+# An simple function that handels the debug output.
+# Checks if $SDEBUG is true. When @param "false" is
+# given on call, you can disable debug mode on any file/line.
+#
+# @param bool "false"
+bs_debug() {
 
-    return 0
+    set +o nounset
+
+    if [ "$1" == false ]; then
+    
+        SDEBUG=false    
+        set +o xtrace    
+    
+    elif [ ${SDEBUG} == true ]; then
+
+        # open a new file descriptor for logging
+        exec 5> "${DEBUG_FILE}"
+        # redirect trace logs to fd 5
+        BASH_XTRACEFD=5
+        # format output
+        PS4='- [T]: $(date "+%H:%M:%S") [F]: $(basename ${BASH_SOURCE[0]}) [M]: ${FUNCNAME[0]} [L]: $LINENO [C]: '
+   
+        # activate debug to file
+        set -o xtrace
+
+    else
+         SDEBUG=false    
+        set +o xtrace 
+    fi
 
 }
+
+
 # Bash error library handler
 # This is an own self written error handler, to handle function
 # and command errors during the runtime/developemnt.

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -172,28 +172,19 @@ bs_error_cli() {
 # @param bool "false"
 bs_debug() {
 
-    set +o nounset
+    switch="${1}"
 
-    if [ "$1" == false ]; then
-    
-        SDEBUG=false    
-        set +o xtrace    
-    
-    elif [ ${SDEBUG} == true ]; then
-
+    if [ "${switch}" == "auto" ] || [ "${switch}" == true ]; then
         # open a new file descriptor for logging
         exec 5> "${DEBUG_FILE}"
         # redirect trace logs to fd 5
         BASH_XTRACEFD=5
         # format output
         PS4='- [T]: $(date "+%H:%M:%S") [F]: $(basename ${BASH_SOURCE[0]}) [M]: ${FUNCNAME[0]} [L]: $LINENO [C]: '
-   
         # activate debug to file
         set -o xtrace
-
-    else
-         SDEBUG=false    
-        set +o xtrace 
+    elif [ "$1" == false ]; then
+        set +o xtrace
     fi
 
 }
@@ -293,3 +284,25 @@ bs_clean() {
     fi
     return 0
 }
+
+
+#### DONT #### EDIT #### DONT #### EDIT #### DONT #### EDIT #### DONT #### EDIT ##
+## DONT #### EDIT #### DONT #### EDIT #### DONT #### EDIT #### DONT #### EDIT #### 
+# DONT #### EDIT #### DONT #### EDIT #### DONT #### EDIT #### DONT #### EDIT ####  
+
+# Checks if debug mode is set to auto enabled or if an
+# command option (-youropt) is given on script call
+if [ ${DEBUG_AUTO} == true ]; then    
+    # call debug function
+    bs_debug auto
+else    
+    # check if arg is DEBUG_OPT
+    for i in "${@}"
+    do 
+        if [ "${i}" == "${DEBUG_OPT}" ];then    
+        # call debug function
+            bs_debug true
+        fi
+    done
+    
+fi

--- a/package.json
+++ b/package.json
@@ -11,5 +11,11 @@
   "bugs": {
     "url": "https://github.com/iptoux/bash_error_lib/issues"
   },
+  "keywords": [
+    "bash",
+    "cli",
+    "error_handler",
+    "library"
+  ],
   "homepage": "https://github.com/iptoux/bash_error_lib#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bash_error_lib",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "bash standalone error library for your scripts.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Done**

```
iptoux@2040:~/gits/bash_error_lib$ ./basherr.sh
iptoux@2040:~/gits/bash_error_lib$ cat 12.15.22_1835637.log 
- [T]: 22:38:47 [F]: basherr.sh [M]:  [L]: 26 [C]: trap 'bs_error "$?" "${FUNCNAME[0]}"' ERR
- [T]: 22:38:47 [F]: basherr.sh [M]:  [L]: 27 [C]: trap 'bs_error "$?" "${FUNCNAME[0]}"' EXIT
- [T]: 22:38:47 [F]: basherr.sh [M]:  [L]: 28 [C]: trap bs_clean EXIT
- [T]: 22:38:47 [F]: basherr.sh [M]:  [L]: 42 [C]: bs_debug false
- [T]: 22:38:47 [F]: bash_error_lib [M]: bs_debug [L]: 176 [C]: switch=false
- [T]: 22:38:47 [F]: bash_error_lib [M]: bs_debug [L]: 178 [C]: '[' false == auto ']'
- [T]: 22:38:47 [F]: bash_error_lib [M]: bs_debug [L]: 178 [C]: '[' false == true ']'
- [T]: 22:38:47 [F]: bash_error_lib [M]: bs_debug [L]: 187 [C]: '[' false == false ']'
- [T]: 22:38:47 [F]: bash_error_lib [M]: bs_debug [L]: 188 [C]: set +o xtrace
iptoux@2040:~/gits/bash_error_lib$ 
```

**How it works**

the library lookup if an argument is given when script is called on cli, like `./basherr.sh -d`. If not, you can enable/disable it on any line in your script by calling `bs_debug (bool)`.

An example can be found in source of `./basherr.sh` in git repo. The function will create a new log for every runtime, so you can easily debug between edits.