### PR TITLE
7 bug external errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
     <img src="https://img.shields.io/github/package-json/keywords/iptoux/bash_error_lib?style=flat-square" title="GitHub package.json dynamic"> 
 </p>
 
-This is an bash error "library", an error handler for any kind of bash script. The library catches mostly all defaults script errors and syntax erros by an trap and displays/logs them.
+This is an bash error "library", an error handler for any kind of bash script. The library catches mostly all  script errors and syntax erros by an trap and displays/logs them. The library includes:
+
+- error logging
+- debug logging
+- display stack
+- colors & themes
+- STANDALONE SINGLEFILE!
 
 ## Index
 
@@ -37,13 +43,17 @@ An Package, an all in one suite, that is easy to include and use.
 
 ## How it works
 ---
-An trap, set in the begin of any bash script, calls the error handler function. The function reads, validates the error, build an array that contains all needed informations for output. After that, the logger is called, than the cli output.
+An trap, set in the begin of any kind of bash script, calls the error handler function. The function reads the vars given by trap. Than it loads the error from the redirected stderr and merges them into and error container. After some checks of user variables(debug/log/stack), the output message will be build and printed.
 
 ## Control
 
-- Option to exit on error
-- Option to display source code snipped (from called error)
-- Oprion to log in an error file
+- [ ] Option to exit on error
+- [x] Option to enable/disable logging (file)
+- [x] Option to display errorstack
+- [x] Option to display source code snipped (from called error)
+- [x] Oprion to log in an error file
+- [x] Option to enable debug (also via cmd option)
+
 
 ## Screenshots/Output
 ---
@@ -53,27 +63,33 @@ An trap, set in the begin of any bash script, calls the error handler function. 
 iptoux@2040:~/gits/bash_error_lib$ ./basherr.sh 
 
 ------------------------------------------------
+>> ERROR (1) - General/External script error.
 
->> ERROR (127) - Command (func) not found.
->> -> somecommand <-
+>> MSG: No such file or directory
+>> CALL/CMD/ARG: lol
 
->> Caused by:  Source.
->> At file: ./basherr.sh on or near line 42
+>> CAUSE BY: cat IN: ./basherr.sh ON LINE: 50
+>> FULLSTACK:
+    huhu @ ./basherr.sh:50
+    main @ ./basherr.sh:54
 
->> Exit on error: true
->> Code-snipped: true
+>> SNIPPED:
 
-------------------------------------------------
-
->> -> 08 lines of source from ./basherr.sh <-
+>> -> 08 lines of source from  <-
 >> {
-L:38      
-L:39      # Unknown command or an unknown function of
-L:40      # script.
-L:41      
-L:42   >>>somecommand
+L:46      #somecommand        # <-
+L:47      
+L:48      huhu() {
+L:49      
+L:50   >>>    cat lol
+L:51      
+L:52      }
+L:53      
+L:54      huhu
 >> }
 
+>> There are 6 log files in folder, cleaning....
+>> Execution time: 0.322949 seconds
 iptoux@2040:~/gits/bash_error_lib$ 
 ```
 
@@ -94,40 +110,39 @@ iptoux@2040:~/gits/bash_error_lib$
 
 **LOG**
 ```
-#### + 22:53:57 + ###################### ERROR ########################
-##
-##	Exitcode: 127		|	Msg: command not found
-##
-##	>>> somecommand
-##
-##	------------------------------------------------------------
-##
-##	Call from:  Source.		|	Line: 42
-##
-##	File: ./basherr.sh
-##
-##	------------------------------------------------------------
-##
-##		>>> 08 lines of source code (snipped) <<<
-##
-## {
-##	L:38      
-##	L:39      # Unknown command or an unknown function of
-##	L:40      # script.
-##	L:41      
-##	L:42   >>>somecommand
-## }
-##
-########################################################## EXIT #######
+>> Date/Time: 23.12.2022 - 23:44:38
+------------------------------------------------
+>> ERROR (1) - General/External script error.
+
+>> MSG: No such file or directory
+>> CALL/CMD/ARG: lol
+
+>> CAUSE BY: cat IN: ./basherr.sh ON LINE: 50
+>> FULLSTACK:
+    huhu @ ./basherr.sh:50
+    main @ ./basherr.sh:54
+
+>> SNIPPED:
+
+>> -> 08 lines of source from  <-
+>> {
+L:46      #somecommand        # <-
+L:47      
+L:48      huhu() {
+L:49      
+L:50   >>>    cat lol
+L:51      
+L:52      }
+L:53      
+L:54      huhu
+>> }
 ```
 
 ---
 
 **IMAGES**
 
-![CLI](../assets/cli.png?raw=true)
-
-![LOG](../assets/log.png?raw=true)
+comming soon.
 
 ## HowTo
 ---
@@ -149,9 +164,10 @@ Source file in your script
 Set Traps
 
 ```
-trap 'bs_error "$?" "${FUNCNAME[0]}"' ERR
-trap 'bs_error "$?" "${FUNCNAME[0]}"' EXIT
-trap 'bs_clean' EXIT
+# setting up Traps
+trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' ERR
+trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' EXIT
+
 ```
 
 **Done**
@@ -160,8 +176,8 @@ Yes! thats all, now the library is ready an loaded in your script when you run i
 
 ## Example?
 
-`The basherr.sh in the repo is an example, that shows how to include in your script and calls errors. All files are "well" documented.
+The `basherr.sh` in the repo is an example, that shows how to include in your script and calls errors. All files are "well" documented.
 
 ## ToDo
 
-- More documentation
+- [ ] More documentation

--- a/basherr.sh
+++ b/basherr.sh
@@ -23,9 +23,9 @@ bs_debug true                               # after sourcing of lib or by comman
 
 ############ LOAD TRAPS ############
 
-# setting up Traps
-trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' ERR
-trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' EXIT
+trap 'bs_error "$?" "${FUNCNAME[0]}"' ERR
+trap 'bs_error "$?" "${FUNCNAME[0]}"' EXIT
+trap 'bs_clean' EXIT
 
 
 ############ EXAMPLES ############
@@ -44,4 +44,4 @@ bs_debug false                              # Can be disabled at any line
 # Unknown command or an unknown function of
 # script.
 
-somecommand        # <-
+#somecommand        # <-

--- a/basherr.sh
+++ b/basherr.sh
@@ -44,4 +44,4 @@ bs_debug false                              # Can be disabled at any line
 # Unknown command or an unknown function of
 # script.
 
-#somecommand        # <-
+somecommand        # <-

--- a/basherr.sh
+++ b/basherr.sh
@@ -23,9 +23,9 @@ bs_debug true                               # after sourcing of lib or by comman
 
 ############ LOAD TRAPS ############
 
-trap 'bs_error "$?" "${FUNCNAME[0]}"' ERR
-trap 'bs_error "$?" "${FUNCNAME[0]}"' EXIT
-trap 'bs_clean' EXIT
+# setting up Traps
+trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' ERR
+trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' EXIT
 
 
 ############ EXAMPLES ############
@@ -44,4 +44,4 @@ bs_debug false                              # Can be disabled at any line
 # Unknown command or an unknown function of
 # script.
 
-#somecommand        # <-
+somecommand        # <-

--- a/basherr.sh
+++ b/basherr.sh
@@ -38,10 +38,20 @@ trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' EXIT
 #}                  # <-
 #hello_world        # <-
 
-# Disable debug output
-bs_debug false                              # Can be disabled at any line
+
 
 # Unknown command or an unknown function of
 # script.
 
-somecommand        # <-
+#somecommand        # <-
+
+huhu() {
+
+    cat lol
+
+}
+
+huhu
+
+# Disable debug output
+bs_debug false                              # Can be disabled at any line

--- a/basherr.sh
+++ b/basherr.sh
@@ -23,9 +23,9 @@ bs_debug true                               # after sourcing of lib or by comman
 
 ############ LOAD TRAPS ############
 
-trap 'bs_error "$?" "${FUNCNAME[0]}"' ERR
-trap 'bs_error "$?" "${FUNCNAME[0]}"' EXIT
-trap 'bs_clean' EXIT
+# setting up Traps
+trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' ERR
+trap 'bs_error_trap "$?" "${BASH_SOURCE[0]}" "${LINENO}" "${FUNCNAME}"' EXIT
 
 
 ############ EXAMPLES ############

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -208,7 +208,7 @@ bs_debug() {
 error_read_file() {
 
     # Read content from file
-    IFS=':' read -d '' -ra err_array < 'errors.log'
+    IFS=':' read -d '' -ra err_array < 'stderr'
 
         # 4 (internal) ->= default error message (with arg)
         #-> ./test.sh: line 75: lol: command not found         <- 
@@ -254,6 +254,62 @@ error_read_file() {
     #rm 'stderr'
 }
 
+# Merge ARG VARS
+#
+# This function merges the VARS - TARGS & FARGS into an error conatiner var
+# Check for empty args, check for matching lines
+error_merge_vars(){
+
+    #TARGS - CODE // FILE // LINE // FUNC
+    #FARGS - FILE // LINE // CALL // MSG
+
+    # FIll empty args with N/A
+    if [[ -v "${FARGS["call"]}" ]]; then
+        echo "Set"
+        FARGS["call"]="N/A"
+    fi
+
+    # Fill container...
+    ECONT["code"]="${TARGS["code"]}"
+    ECONT["type"]=$(error_code_matcher "${TARGS["code"]}")           # check wich type of error (error code/extern)
+    ECONT["msg"]="${FARGS["msg"]}"  #//\\n/
+    
+    
+    # Check if it is an Syntax error and re-order vars
+    # If true, we read from external error file.
+    if [ "${FARGS["call"]}" == "syntax error" ]; then
+        ECONT["call"]=" Script"
+        ECONT["cause"]="${FARGS["call"]}"
+    elif [ "${TARGS["func"]}" == "efile" ]; then
+        ECONT["call"]="${FARGS["call"]}"
+        ECONT["cause"]="Syntax error"
+    else
+        ECONT["call"]="${FARGS["call"]}"
+        ECONT["cause"]="${TARGS["func"]}"
+    fi
+    
+    ECONT["source"]="${TARGS["file"]}"
+    
+    # Match lines to get always the same
+    if [[ "${TARGS["line"]}" -eq "${FARGS["line"]}" ]]; then
+        ECONT["line"]="${TARGS["line"]}"
+    else
+        # Checks if FARGS-line is empty
+        if [[ -z ${FARGS["line"]} ]]; then
+            ECONT["line"]="${TARGS["line"]}"
+        else
+            ECONT["line"]="${FARGS["line"]}"
+        fi
+    fi
+    
+    # Check if is external command error
+    if [ "${isExt}" == true ]; then
+        ECONT["cause"]="${FARGS["file"]}"
+    fi
+
+    # done
+    return 0
+}
 
 # Bash error library handler
 # This is an own self written error handler, to handle function

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -74,62 +74,6 @@ BECD[128]="Invalid argument to exit."
 BECD[130]="Script terminated by Control-C."
 
 
-# Bash error logging, the output printed in an error log file.
-# This function builds the style of the log entry. Variables are stored
-# global in eout[@]
-bs_error_log() {
-
-    # check if logging of errors in enabled.
-    if [ "${ERROR_LOG}" == true ]; then
-
-        # part of theme (line-split)
-        lsp="##\n"
-
-        # generate head
-        emsg_head="\n#### + ${eout[0]} + ###################### ERROR ######################${lsp}"
-        emsg_head+="${lsp}"
-        
-        # generate body
-        emsg_body="##\tExitcode: ${eout[1]}\t\t|\tMsg:${eout[2]}\n"
-        emsg_body+="${lsp}##\t>>>${eout[3]}\n"
-        emsg_body+="${lsp}##\t------------------------------------------------------------\n"
-        emsg_body+="${lsp}##\tCall from: ${eout[4]}\t\t|\tLine: ${eout[6]}\n"
-        emsg_body+="${lsp}##\tFile: ${eout[5]}\n"
-
-        # show source file output on failed line?
-        # if yes, new split, else go to footer.
-
-            if [ "${ERROR_SRC_SNIPPED}" == true ]; then
-                # add output
-                eded="${lsp}##\t------------------------------------------------------------\n"
-                eded+="${lsp}##\t\t>>> 08 lines of source code (snipped) <<<\n"
-                eded+="${lsp}## {\n"
-
-                regfile=${eout[5]}
-
-                regex=$(awk 'NR>L-5 && NR<L+5 { printf "##\tL:%-5d%3s%s\n",NR,(NR==L?">>>":""),$regfile }' L="${eout[6]}" "${eout[5]}")
-                
-                eded+="${regex}\n## }\n"
-
-                emsg_body+="${eded}"
-            fi
-
-        # generate footer
-
-        if [ "${ERROR_EXIT}" == false ] && [ "${eout[7]}" == false ]; then
-            emsg_footer+="${lsp}################################################# SKIP ERROR #####${lsp}"    
-            else
-            emsg_footer+="${lsp}########################################################## EXIT #####${lsp}"
-        fi
-
-        # combine head+body+footer to one var
-        emsg="${emsg_head}${emsg_body}${emsg_footer}"
-
-        echo -e "${emsg}" >> "${ERROR_FILE}"
-        return 0
-    fi
-}
-
 # An simple function that handels the debug output.
 # Checks if $SDEBUG is true. When @param "false" is
 # given on call, you can disable debug mode on any file/line.
@@ -315,6 +259,34 @@ error_out_msg() {
     
 }
 
+# Bash error logging, the output printed in an error log file.
+# This function builds the style of the log entry.
+error_out_log() {
+
+    local logtime mode
+
+    unset mode logtime
+
+    mode=$1
+
+        case ${mode} in
+            fancy)
+                # load (user) theme frome file
+            ;;
+            *)  # default output to logfile (same as onscreen)
+                # adding Logtime
+                logtime=$(date +%d.%m.%Y' - '%H:%M:%S)
+                OUTMSG_LOG="\n>> Date/Time: ${logtime}"
+                OUTMSG_LOG+="${OUTMSG}"
+            ;;
+        esac
+
+        # Write output to logfile...
+        echo -e "${OUTMSG_LOG}" >> "${ERROR_FILE}"
+
+}
+
+
 error_read_src() {
 
     local prfx
@@ -356,7 +328,7 @@ bs_error_trap() {
         # exit (0) or error -> jump to cleanup if true
         if [[ ${TARGS["code"]} -eq 0 ]] || [[ ${rerun} -eq 1 ]]; then
             unset rerun
-            bs_clean
+            error_exit_clean
             return 0
         fi
 
@@ -393,19 +365,25 @@ bs_error_trap() {
     if [ "${ERROR_DISP_SNIPPED}" == true ]; then
         error_read_src
     fi
-    
+
+    # Check if logging of errors in enabled.
+    if [ "${ERROR_LOG}" == true ]; then
+        error_out_log ""
+    fi
+
     echo -e "${OUTMSG}"
 
     # don't re_run on script exit call
     rerun=1
 
+    # Check if Exit on error is true.
     if [ "${ERROR_EXIT}" == true ]; then
         exit 1
     fi
 
 }
 
-bs_clean() {
+error_exit_clean() {
 
     local dur
 

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -30,6 +30,7 @@ DEBUG_OPT="-debug"
 set +o errexit  # Deactivate default Exit after first command failure.
 set -E
 
+
 # DATE for log file names.
 DATE=$(date +%m.%d.%y)
 
@@ -44,6 +45,11 @@ exec 2> 'stderr'
 ##################################################################
 ############ DONT ############ EDIT ############ HERE ############
 ##################################################################
+
+# Unsetting ARGS to start fresh
+unset TARGS 
+unset FARGS
+unset ECONT
 
 ############ HANDLER VARS/SETS ############
 # Declaring all needed Container array's variables, lists
@@ -60,10 +66,6 @@ ECD[127]="Command (func) not found."
 ECD[128]="Invalid argument to exit."
 ECD[130]="Script terminated by Control-C."
 
-
-
-
-unset eout
 
 # Bash error logging, the output printed in an error log file.
 # This function builds the style of the log entry. Variables are stored
@@ -194,6 +196,62 @@ bs_debug() {
         set +o xtrace
     fi
 
+}
+
+
+#### READ FROM FILE ###
+#######################
+#
+# This function loads the erros information from external error file.
+# After loading, the array lenght will be checked. This is needed to 
+# get the all informations of an error, also if it is external.
+error_read_file() {
+
+    # Read content from file
+    IFS=':' read -d '' -ra err_array < 'errors.log'
+
+        # 4 (internal) ->= default error message (with arg)
+        #-> ./test.sh: line 75: lol: command not found         <- 
+        #
+        # 3 (external) ->= needs check, if trap gives needed vales.        
+        #-> cat: lol: No such file or directory            <- 
+        #        
+        # 3 (internal) ->= default error message (without arg)
+        #./test.sh: line 83: syntax error near unexpected token `}'
+        if [[ ${#err_array[@]} -eq 5 ]]; then
+            
+            #echo "Multiline error/errors"
+            FARGS["file"]=${err_array[0]}
+            FARGS["line"]=${err_array[1]##* }
+            FARGS["call"]=${err_array[4]//$'\n'/} # ${dt//$'\n'/} # Remove all newlines. ${dt%$'\n'}  # Remove a trailing newline. 
+            FARGS["msg"]=$(echo "${err_array[2]}" | cut -d '.' -f1)
+            # Add new line
+            FARGS["msg"]="${FARGS["msg"]}
+"
+        elif [[ ${#err_array[@]} -eq 4 ]]; then
+            # "Sinleline default (4) with argument/cmd"
+            FARGS["file"]=${err_array[0]}
+            FARGS["line"]=${err_array[1]##* }
+            FARGS["call"]=${err_array[2]}
+            FARGS["msg"]=${err_array[3]}
+        elif [ -n "${err_array[1]##* }" ] && [ "${err_array[1]##* }" -eq "${err_array[1]##* }" ] 2>/dev/null; then
+                # "Singleline default (3) without argument/cmd"
+                FARGS["file"]=${err_array[0]}
+                FARGS["line"]=${err_array[1]##* }
+                FARGS["msg"]=${err_array[2]}
+        else
+                # "Singleline default external error by internal call, no line, source, func."
+                FARGS["file"]=${err_array[0]}
+                FARGS["call"]=${err_array[1]}
+                FARGS["msg"]=${err_array[2]}
+
+                # this is an external error.
+                declare -g isExt=true
+
+        fi    
+
+    #delete tmp_err file
+    #rm 'stderr'
 }
 
 

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -14,6 +14,9 @@
 # For more details read&visit 
 # https://github.com/iptoux/bash_error_lib/wiki
 
+MTSTART=$(date +%s.%N)
+
+
 ############ LIBRARY VARIABLES ############
 
 # Error
@@ -34,7 +37,7 @@ set -E
 # DATE for log file names.
 DATE=$(date +%m.%d.%y)
 
-LOG_DIR=""
+LOG_DIR="logs/"
 ERROR_FILE=${LOG_DIR}${DATE}'_error.log'
 DEBUG_FILE=${LOG_DIR}${DATE}'_'${DEBUG_PID}'.log'
 
@@ -234,11 +237,22 @@ error_read_file() {
             FARGS["call"]=${err_array[2]}
             FARGS["msg"]=${err_array[3]}
         elif [ -n "${err_array[1]##* }" ] && [ "${err_array[1]##* }" -eq "${err_array[1]##* }" ] 2>/dev/null; then
+            if [[ ${#err_array[@]} -gt 5 ]]; then
+                # "multiline args bigger than 5 / some external call"
+                FARGS["file"]=${err_array[0]}
+                FARGS["line"]=${err_array[1]##* }
+                FARGS["call"]=${err_array[2]}
+                FARGS["msg"]=$(echo "${err_array[3]}" | cut -d $'\n' -f1)
+                FARGS["msg"]+="\n"
+
+            else
                 # "Singleline default (3) without argument/cmd"
                 FARGS["file"]=${err_array[0]}
                 FARGS["line"]=${err_array[1]##* }
                 FARGS["msg"]=${err_array[2]}
+            fi
         else
+                echo "yes"
                 # "Singleline default external error by internal call, no line, source, func."
                 FARGS["file"]=${err_array[0]}
                 FARGS["call"]=${err_array[1]}
@@ -369,7 +383,6 @@ bs_error_trap() {
         # Check if script is called by default script 
         # exit (0) or error -> jump to cleanup if true
         if [[ ${TARGS["code"]} -eq 0 ]] || [[ ${rerun} -eq 1 ]]; then
-            echo "Jumping to cleanUp!"
             unset rerun
             bs_clean
             return 0
@@ -412,10 +425,15 @@ bs_error_trap() {
 }
 
 bs_clean() {
+
+    local dur
+
     if [ -f 'stderr' ]; then
-        rm 'stderr'
+         rm 'stderr'
     fi
-    echo "done."
+    
+    dur=$(echo "$(date +%s.%N)"-"${MTSTART}" | node -p)
+    printf ">> Execution time: %.6f seconds\n" "${dur}"
     return 0
 }
 

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -59,12 +59,12 @@ declare -gA ECONT                                       # CONTAINER ERROR VARIAB
 #declare -A eout
 declare -A BECD                                          # CONTAINER ERROR VARIABLE CODE NAMES
 
-ECD[1]="General/External script error."
-ECD[2]="Bash script error."
-ECD[126]="Command invoked cannot be exec."
-ECD[127]="Command (func) not found."
-ECD[128]="Invalid argument to exit."
-ECD[130]="Script terminated by Control-C."
+BECD[1]="General/External script error."
+BECD[2]="Bash script error."
+BECD[126]="Command invoked cannot be exec."
+BECD[127]="Command (func) not found."
+BECD[128]="Invalid argument to exit."
+BECD[130]="Script terminated by Control-C."
 
 
 # Bash error logging, the output printed in an error log file.
@@ -271,7 +271,7 @@ error_merge_vars(){
 
     # Fill container...
     ECONT["code"]="${TARGS["code"]}"
-    ECONT["type"]=$(error_code_matcher "${TARGS["code"]}")           # check wich type of error (error code/extern)
+    ECONT["type"]="${BECD["${TARGS["code"]}"]}"
     ECONT["msg"]="${FARGS["msg"]}"  #//\\n/
     
     
@@ -309,6 +309,24 @@ error_merge_vars(){
 
     # done
     return 0
+}
+
+error_out_msg() {
+
+    local prfx cli_out
+
+    prfx=">> "
+
+    cli_out="\n------------------------------------------------\n"
+
+    cli_out+="${prfx}ERROR (${ECONT["code"]}) - ${ECONT["type"]}\n\n"
+    cli_out+="${prfx}MSG:${ECONT["msg"]}"
+    cli_out+="${prfx}CALL/CMD/ARG:${ECONT["call"]}\n\n"
+    cli_out+="${prfx}CAUSE BY: ${ECONT["cause"]} IN: ${ECONT["source"]} ON LINE: ${ECONT["line"]}\n"
+    cli_out+="${prfx}FULLSTACK:"
+
+    echo -e "${cli_out}"
+    
 }
 
 # Bash error library handler

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -150,7 +150,7 @@ error_read_file() {
                 FARGS["msg"]=${err_array[2]}
             fi
         else
-                echo "yes"
+                
                 # "Singleline default external error by internal call, no line, source, func."
                 FARGS["file"]=${err_array[0]}
                 FARGS["call"]=${err_array[1]}
@@ -192,16 +192,22 @@ error_merge_vars(){
     if [ "${FARGS["call"]}" == "syntax error" ]; then
         ECONT["call"]=" Script"
         ECONT["cause"]="${FARGS["call"]}"
-    elif [ "${TARGS["func"]}" == "efile" ]; then
+    elif [ "${TARGS["func"]}" == "error_read_file" ]; then
         ECONT["call"]="${FARGS["call"]}"
-        ECONT["cause"]="Syntax error"
+        ECONT["cause"]="main"
     else
         ECONT["call"]="${FARGS["call"]}"
         ECONT["cause"]="${TARGS["func"]}"
     fi
     
-    ECONT["source"]="${TARGS["file"]}"
-    
+    if [ "${TARGS["file"]}" != "${FARGS["file"]}" ]; then
+        ECONT["source"]="${TARGS["file"]}"
+    elif [ "${FARGS["file"]}" != "${TARGS["file"]}" ]; then
+        ECONT["source"]="${FARGS["file"]}"
+    else
+        ECONT["source"]="${TARGS["file"]}"
+    fi
+
     # Match lines to get always the same
     if [[ "${TARGS["line"]}" -eq "${FARGS["line"]}" ]]; then
         ECONT["line"]="${TARGS["line"]}"
@@ -236,11 +242,11 @@ error_stacktrace() {
 
     # loop through frames (func calls)
     while read -r LINE SUB FILE < <(caller "${frame}"); do
-        OUTMSG+=$(printf '  %s @ %s:%s\n' "${SUB}" "${FILE}" "${LINE}")
+        OUTMSG+="    ${SUB} @ ${FILE}:${LINE}\n"
+        #OUTMSG+=$(printf '  %s @ %s:%s\n\n' "${SUB}" "${FILE}" "${LINE}")
         ((frame++))
     done
 
-    OUTMSG+="\n"
 }
 
 
@@ -390,6 +396,14 @@ error_exit_clean() {
     if [ -f 'stderr' ]; then
          rm 'stderr'
     fi
+
+    count_debug_logs=$(find ${LOG_DIR}$(date +%m.%d.%y)_debug* | wc -l)
+    
+        if [[ ${count_debug_logs} -gt ${LOG_MAXCOUNT} ]]; then
+            printf ">> There are %s log files in folder, cleaning....\n" "${count_debug_logs}"
+
+            rm ${LOG_DIR}$(date +%m.%d.%y)_debug*
+        fi
     
     dur=$(echo "$(date +%s.%N)"-"${MTSTART}" | node -p)
     printf ">> Execution time: %.6f seconds\n" "${dur}"

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -271,7 +271,8 @@ error_merge_vars(){
 
     # Fill container...
     ECONT["code"]="${TARGS["code"]}"
-    ECONT["type"]="${BECD["${TARGS["code"]}"]}"
+
+    ECONT["type"]="${BECD[${TARGS["code"]}]}"
     ECONT["msg"]="${FARGS["msg"]}"  #//\\n/
     
     
@@ -310,6 +311,22 @@ error_merge_vars(){
     # done
     return 0
 }
+
+# This is the function to get and build stack
+error_stacktrace() {
+    
+    #define local function vars
+    local frame=1 LINE SUB FILE
+
+    # loop through frames (func calls)
+    while read -r LINE SUB FILE < <(caller "${frame}"); do
+        printf '  %s @ %s:%s\n' "${SUB}" "${FILE}" "${LINE}"
+        ((frame++))
+    done
+    
+    echo ""
+}
+
 
 error_out_msg() {
 

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -56,7 +56,6 @@ unset ECONT
 declare -A TARGS                                        # ARGS FROM TRAP
 declare -gA FARGS                                       # ARGS FROME FILE
 declare -gA ECONT                                       # CONTAINER ERROR VARIABLES (MERGE)
-#declare -A eout
 declare -A BECD                                          # CONTAINER ERROR VARIABLE CODE NAMES
 
 BECD[1]="General/External script error."
@@ -372,6 +371,7 @@ bs_error_trap() {
         if [[ ${TARGS["code"]} -eq 0 ]] || [[ ${rerun} -eq 1 ]]; then
             echo "Jumping to cleanUp!"
             unset rerun
+            bs_clean
             return 0
         fi
 
@@ -414,8 +414,8 @@ bs_error_trap() {
 bs_clean() {
     if [ -f 'stderr' ]; then
         rm 'stderr'
-        return
     fi
+    echo "done."
     return 0
 }
 

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -40,11 +40,20 @@ DEBUG_FILE=${LOG_DIR}${DATE}'_'${DEBUG_PID}'.log'
 # Redirect stderr to file for parsing errors....
 exec 2> 'stderr'
 
-############ HANDLER VARS/SETS ############
-declare -A eout
-declare -A ECD
+######################## BEGIN OF LIBRARY ########################
+##################################################################
+############ DONT ############ EDIT ############ HERE ############
+##################################################################
 
-ECD[1]="General script error."
+############ HANDLER VARS/SETS ############
+# Declaring all needed Container array's variables, lists
+declare -A TARGS                                        # ARGS FROM TRAP
+declare -gA FARGS                                       # ARGS FROME FILE
+declare -gA ECONT                                       # CONTAINER ERROR VARIABLES (MERGE)
+#declare -A eout
+declare -A BECD                                          # CONTAINER ERROR VARIABLE CODE NAMES
+
+ECD[1]="General/External script error."
 ECD[2]="Bash script error."
 ECD[126]="Command invoked cannot be exec."
 ECD[127]="Command (func) not found."
@@ -52,10 +61,7 @@ ECD[128]="Invalid argument to exit."
 ECD[130]="Script terminated by Control-C."
 
 
-######################## BEGIN OF LIBRARY ########################
-##################################################################
-############ DONT ############ EDIT ############ HERE ############
-##################################################################
+
 
 unset eout
 
@@ -203,79 +209,57 @@ bs_debug() {
 # @param $errmsg | @output err
 bs_error() {
 
-    # check if function called by trap or pipe
-    if [ -n "$1" ]; then
-           set +u
-        # checks if function is called by an error.
-        if [[ $1 -gt 0 ]] && [ -f 'stderr' ]; then
-            
-            # Store time of error in variable
-            err_time=$(date "+%H:%M:%S")
+    # oldvars, needed?
+    #err_time=$(date "+%H:%M:%S")
 
-            # get error code/func from call/arg
-            error_code="$1"
+    declare -g rerun
 
-            error_func="$2"
+    # get lenght of TARGS (for function name (4))
+    TARGS_LEN=${#*}
+    TARGS["code"]="${1}"
 
-             if [ "$2" == "" ]; then
-                if [[ ${error_code} -eq 2 ]]; then
-                    error_func=" Syntax error."
-                else
-                    error_func=" Source."
-                fi
-             fi
-
-            # read error from file (set in setup.sh via exec 3> stderr;exec 2>&3)
-            IFS=':' read -ra err_array < 'stderr'
-
-                error_source=${err_array[0]}
-                error_line=${err_array[1]##* }
-                error_cmd=${err_array[2]}
-                error_code_desc=${err_array[3]}
-
-            #echo "${err_array[@]}"
-
-            if [[ "$1" -eq "2" ]]; then
-                ERROR_EXIT=true
-            fi
-
-            #delete tmp_err file
-            rm 'stderr'
-            
-            
-            
-            # store all in an array to build variable out messages.
-            eout[0]=${err_time}
-            eout[1]=${error_code}
-            eout[2]=${error_code_desc}
-            eout[3]=${error_cmd}
-            eout[4]=${error_func}
-            eout[5]=${error_source}
-            eout[6]=${error_line}
-            eout[7]=false
-
-            # error in bash script, needed when no exit trap 
-            # is used to catch errors.
-            if [[ "$1" -eq "2" ]]; then
-                eout[7]=true
-            fi
-
-            # logging error to logfile (if true)
-            bs_error_log 
-
-            # show error on cli
-            bs_error_cli
-
-            if [ "${ERROR_EXIT}" == true ] || [ "${eout[7]}" == true ]; then
-                exit 0
-            fi
-
+        # Check if script is called by default script 
+        # exit (0) or error -> jump to cleanup if true
+        if [[ ${TARGS["code"]} -eq 0 ]] || [[ ${rerun} -eq 1 ]]; then
+            echo "Jumping to cleanUp!"
+            unset rerun
+            return 0
         fi
-    else
-        # function called by pipe
-        echo "pipe"
+
+    TARGS["file"]="${2}"
+    TARGS["line"]="${3}"
+       
+        # Check if lenght of args is 4 (function is given?)
+        if [[ ${TARGS_LEN} -eq 4 ]]; then
+            if [[ -z "$4" ]]; then
+                TARGS["func"]="Script"
+            else
+                TARGS["func"]="${4}"
+            
+            fi
+        else
+            TARGS["func"]="N/A"
+        fi
+
+    # Load data from file
+    error_read_file
+
+    # Merge vars
+    error_merge_vars
+
+    # Generate and output msg
+    error_out_msg
+
+    # Display stack->trace
+    error_stacktrace
+
+    # don't re_run on script exit call
+    rerun=1
+
+    if [ "${ERROR_EXIT}" == true ]; then
+        exit 1
     fi
-    set -u
+
 }
 
 bs_clean() {

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -38,8 +38,11 @@ set -E
 DATE=$(date +%m.%d.%y)
 
 LOG_DIR="logs/"
+LOG_MAXCOUNT=5                                      # How many logs per day' should be keep?
+LOG_MAXDAY=7                                        # How many day' should be keep?
 ERROR_FILE=${LOG_DIR}${DATE}'_error.log'
 DEBUG_FILE=${LOG_DIR}${DATE}'_'${DEBUG_PID}'.log'
+
 
 # Redirect stderr to file for parsing errors....
 exec 2> 'stderr'

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -22,7 +22,8 @@ MTSTART=$(date +%s.%N)
 # Error
 ERROR_EXIT=true
 ERROR_LOG=true
-ERROR_SRC_SNIPPED=true
+ERROR_DISP_SNIPPED=true
+ERROR_DISP_STACK=true
 
 # Debug
 DEBUG_PID=$$
@@ -41,7 +42,7 @@ LOG_DIR="logs/"
 LOG_MAXCOUNT=5                                      # How many logs per day' should be keep?
 LOG_MAXDAY=7                                        # How many day' should be keep?
 ERROR_FILE=${LOG_DIR}${DATE}'_error.log'
-DEBUG_FILE=${LOG_DIR}${DATE}'_'${DEBUG_PID}'.log'
+DEBUG_FILE=${LOG_DIR}${DATE}'_debug_'${DEBUG_PID}'.log'
 
 
 # Redirect stderr to file for parsing errors....
@@ -63,6 +64,7 @@ declare -A TARGS                                        # ARGS FROM TRAP
 declare -gA FARGS                                       # ARGS FROME FILE
 declare -gA ECONT                                       # CONTAINER ERROR VARIABLES (MERGE)
 declare -A BECD                                          # CONTAINER ERROR VARIABLE CODE NAMES
+declare -g OUTMSG
 
 BECD[1]="General/External script error."
 BECD[2]="Bash script error."
@@ -126,57 +128,6 @@ bs_error_log() {
         echo -e "${emsg}" >> "${ERROR_FILE}"
         return 0
     fi
-}
-
-bs_error_cli() {
-
-    clierrout="\n------------------------------------------------\n"
-
-    # Generate cli output, building head
-    if ! [ -n "${eout[2]}" ]; then
-            eout[2]=${eout[3]}
-            clierrout+="\n>> ERROR (${eout[1]}) - ${ECD[2]}\n"
-    else
-        clierrout+="\n>> ERROR (${eout[1]}) - ${ECD[${eout[1]}]}\n"
-    fi
-    
-    # Building body
-    clierrout+=">> ->${eout[3]} <-\n"
-    clierrout+="\n>> Caused by: ${eout[4]}\n"
-    clierrout+=">> At file: ${eout[5]} on or near line ${eout[6]}\n"
-    #clierrout+=">> In: ${eout[4]}\n"
-
-    if  [ "${eout[7]}" == true ]; then
-        clierrout+="\n>> Exit on error: (auto) default\n"
-    else
-        clierrout+="\n>> Exit on error: ${ERROR_EXIT}\n"
-    fi
-
-    clierrout+=">> Code-snipped: ${ERROR_SRC_SNIPPED}\n"
-
-    # Check if file source snipped should be displayd
-    if [ "${ERROR_SRC_SNIPPED}" == true ]; then
-        if [ "${ERROR_EXIT}" == true ]; then
-
-            clierrout+="\n------------------------------------------------\n"
-            clierrout+="\n>> -> 08 lines of source from ${eout[5]} <-\n"
-            
-            clierrout+=">> {\n"
-
-            regfile=${eout[5]}
-            regex=$(awk 'NR>L-5 && NR<L+5 { printf "L:%-5d%3s%s\n",NR,(NR==L?">>>":""),$regfile }' L="${eout[6]}" "${eout[5]}")
-                    
-            clierrout+="${regex}\n>> }\n"
-        else
-            clierrout+="\nSet EXIT on Error to show!\n"
-        fi
-    fi
-
-    # Actual push to stdrout
-    echo -e "${clierrout}"
-
-    return 0
-
 }
 
 # An simple function that handels the debug output.
@@ -332,34 +283,52 @@ error_merge_vars(){
 error_stacktrace() {
     
     #define local function vars
-    local frame=1 LINE SUB FILE
+    local frame=1 LINE SUB FILE prfx
+
+    prfx=">> "
+    
+    # add blank line
+    OUTMSG+="${prfx}FULLSTACK:\n"
 
     # loop through frames (func calls)
     while read -r LINE SUB FILE < <(caller "${frame}"); do
-        printf '  %s @ %s:%s\n' "${SUB}" "${FILE}" "${LINE}"
+        OUTMSG+=$(printf '  %s @ %s:%s\n' "${SUB}" "${FILE}" "${LINE}")
         ((frame++))
     done
-    
-    echo ""
+
+    OUTMSG+="\n"
 }
 
 
 error_out_msg() {
 
-    local prfx cli_out
+    local prfx
 
     prfx=">> "
 
-    cli_out="\n------------------------------------------------\n"
+    OUTMSG="\n------------------------------------------------\n"
 
-    cli_out+="${prfx}ERROR (${ECONT["code"]}) - ${ECONT["type"]}\n\n"
-    cli_out+="${prfx}MSG:${ECONT["msg"]}"
-    cli_out+="${prfx}CALL/CMD/ARG:${ECONT["call"]}\n\n"
-    cli_out+="${prfx}CAUSE BY: ${ECONT["cause"]} IN: ${ECONT["source"]} ON LINE: ${ECONT["line"]}\n"
-    cli_out+="${prfx}FULLSTACK:"
-
-    echo -e "${cli_out}"
+    OUTMSG+="${prfx}ERROR (${ECONT["code"]}) - ${ECONT["type"]}\n\n"
+    OUTMSG+="${prfx}MSG:${ECONT["msg"]}"
+    OUTMSG+="${prfx}CALL/CMD/ARG:${ECONT["call"]}\n\n"
+    OUTMSG+="${prfx}CAUSE BY: ${ECONT["cause"]} IN: ${ECONT["source"]} ON LINE: ${ECONT["line"]}\n"
     
+}
+
+error_read_src() {
+
+    local prfx
+
+    prfx=">> "
+    OUTMSG+="\n>> SNIPPED:\n"
+    OUTMSG+="\n>> -> 08 lines of source from ${eout[5]} <-\n"
+    OUTMSG+=">> {\n"
+
+    regfile=${ECONT["source"]}
+    regex=$(awk 'NR>L-5 && NR<L+5 { printf "L:%-5d%3s%s\n",NR,(NR==L?">>>":""),$regfile }' L="${ECONT["line"]}" "${ECONT["source"]}")
+                    
+    OUTMSG+="${regex}\n>> }\n"
+
 }
 
 # Bash error library handler
@@ -412,11 +381,20 @@ bs_error_trap() {
     # Merge vars
     error_merge_vars
 
-    # Generate and output msg
+    # Generate default output msg
     error_out_msg
+    
+    # Check if stacktrace should be displayd
+    if [ "${ERROR_DISP_STACK}" == true ]; then
+        error_stacktrace
+    fi
 
-    # Display stack->trace
-    error_stacktrace
+    # Check if file source snipped should be displayd
+    if [ "${ERROR_DISP_SNIPPED}" == true ]; then
+        error_read_src
+    fi
+    
+    echo -e "${OUTMSG}"
 
     # don't re_run on script exit call
     rerun=1

--- a/lib/bash_error_lib
+++ b/lib/bash_error_lib
@@ -207,7 +207,7 @@ bs_debug() {
 # Errors will logged in an file if enabled.
 #
 # @param $errmsg | @output err
-bs_error() {
+bs_error_trap() {
 
     # oldvars, needed?
     #err_time=$(date "+%H:%M:%S")


### PR DESCRIPTION
# Done!

All things are back in library/script. Now the whole library is more modular, so future editing and adding of features should be easier. The library had now the following functions:

- [x] (rewrote) bs_error_trap
- [x] (old) bs_debug
- [x] (rewrote/new) error_read_file
- [x] (rewrote) error_merge_vars
- [x] (new) error_stacktrace
- [x] (rewrote/new) error_out_msg
- [x] (rewrote/new) error_out_log
- [x] (new) error_read_src
- [x] (new) error_exit_clean

Commits branch: https://github.com/iptoux/bash_error_lib/compare/main...7-bug-external-errors

**CLI (all on)**
```
iptoux@2040:~/gits/bash_error_lib$ ./basherr.sh 

------------------------------------------------
>> ERROR (1) - General/External script error.

>> MSG: No such file or directory
>> CALL/CMD/ARG: lol

>> CAUSE BY: cat IN: ./basherr.sh ON LINE: 50
>> FULLSTACK:
    huhu @ ./basherr.sh:50
    main @ ./basherr.sh:54

>> SNIPPED:

>> -> 08 lines of source from  <-
>> {
L:46      #somecommand        # <-
L:47      
L:48      huhu() {
L:49      
L:50   >>>    cat lol
L:51      
L:52      }
L:53      
L:54      huhu
>> }

>> There are 6 log files in folder, cleaning....
>> Execution time: 0.322949 seconds
iptoux@2040:~/gits/bash_error_lib$ 
```

**LOGFILE (simple)**
```
>> Date/Time: 23.12.2022 - 23:37:46
------------------------------------------------
>> ERROR (1) - General/External script error.

>> MSG: No such file or directory
>> CALL/CMD/ARG: lol

>> CAUSE BY: cat IN: ./basherr.sh ON LINE: 50
>> FULLSTACK:
    huhu @ ./basherr.sh:50
    main @ ./basherr.sh:54

>> SNIPPED:

>> -> 08 lines of source from  <-
>> {
L:46      #somecommand        # <-
L:47      
L:48      huhu() {
L:49      
L:50   >>>    cat lol
L:51      
L:52      }
L:53      
L:54      huhu
>> }
```